### PR TITLE
Изменение api-теста

### DIFF
--- a/fixture/api.py
+++ b/fixture/api.py
@@ -18,10 +18,10 @@ class ApiHelper:
             names_list += [product.name]
         return names_list
 
-    def check_Alcatel_in_names(self, names_list):
+    def check_substr_in_names(self, names_list, substr):
         flag = True
         for name in names_list:
-            if 'Alcatel' not in name:
+            if substr not in name:
                 flag = False
         return flag
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -3,6 +3,5 @@ from model.JsTestTask import JsTestTask
 
 def test_api(api):
     request_result = api.get_js_test_task(search_field="Alcatel", sort_field="name")
-    products_names = api.get_names_from_response(request_result)
     assert request_result == sorted(request_result, key=JsTestTask.sort_key)
-    assert api.check_Alcatel_in_names(products_names)
+    assert api.check_substr_in_names(api.get_names_from_response(request_result), 'Alcatel')


### PR DESCRIPTION
1. Проверка "Все поля "name" в ответе на запрос содержат значение 'Alcatel'" реализована более гибко, теперь метод check_substr_in_names принимает вторым параметром строку, которую проверяем в списке названий продуктов